### PR TITLE
Handle memory allocation failures

### DIFF
--- a/src/model_loader.c
+++ b/src/model_loader.c
@@ -27,7 +27,20 @@ model_t load_obj_model(const char *path) {
   }
 
   model.vertices = malloc(sizeof(float) * 3 * v_count);
+  if (!model.vertices) {
+    printf("Could not allocate vertices\n");
+    fclose(f);
+    return (model_t){0};
+  }
+
   model.indices = malloc(sizeof(int) * 3 * f_count);
+  if (!model.indices) {
+    printf("Could not allocate indices\n");
+    free(model.vertices);
+    fclose(f);
+    return (model_t){0};
+  }
+
   model.vertex_count = v_count;
   model.index_count = f_count * 3;
 


### PR DESCRIPTION
## Summary
- handle failed allocations in `load_obj_model`

## Testing
- `make` *(fails: mips64-elf-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4f17cf948328a43f8c192db4bb32