### PR TITLE
Add cleanup and exit condition

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -27,7 +27,16 @@ int main(void) {
     graphics_fill_screen(disp, graphics_make_color(0, 0, 32, 255));
     draw_model(&egg_model, disp, angle);
     display_show(disp);
+
+    // Press START to exit the program loop
+    if (keys.c[0].start)
+      break;
   }
+
+  free_model(&egg_model);
+  rdpq_close();
+  rspq_close();
+  display_close();
 
   return 0;
 }


### PR DESCRIPTION
## Summary
- exit the render loop when START is pressed
- free the OBJ model and release libdragon resources on exit

## Testing
- `make clean all` *(fails: mips64-elf-gcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_683f4f1844048328ab88a2a673858af5