### PR TITLE
Fix free_model null checks and clarify loader return

### DIFF
--- a/include/model_loader.h
+++ b/include/model_loader.h
@@ -3,12 +3,15 @@
 #include <libdragon.h>
 
 typedef struct {
-  float *vertices;
-  int vertex_count;
-  int *indices;
-  int index_count;
+    float *vertices;
+    int vertex_count;
+    int *indices;
+    int index_count;
 } model_t;
 
+// Load a Wavefront OBJ model from disk.
+// Returns an empty model if the file cannot be loaded or memory allocation
+// fails.
 model_t load_obj_model(const char *path);
 void draw_model(model_t *model, surface_t *disp, float angle);
 void free_model(model_t *model);

--- a/src/model_loader.c
+++ b/src/model_loader.c
@@ -207,6 +207,8 @@ void draw_model(model_t *model, surface_t *disp, float angle) {
 }
 
 void free_model(model_t *model) {
-  free(model->vertices);
-  free(model->indices);
+  if (model->vertices)
+    free(model->vertices);
+  if (model->indices)
+    free(model->indices);
 }


### PR DESCRIPTION
## Summary
- avoid freeing NULL pointers in `free_model`
- document that `load_obj_model` can return an empty model

## Testing
- `make clean && make` *(fails: mips64-elf-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c2df90108328a72226d3813e7e14