### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Build artifacts
+build/
+
+# Nintendo 64 ROM and binary outputs
+*.z64
+*.elf
+*.bin


### PR DESCRIPTION
## Summary
- ignore build artifacts and compiled ROM binaries

## Testing
- `make` *(fails: mips64-elf-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c2dea6808328aa1efccb184b662c