### PR TITLE
Allow LIBDRAGON path override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 ROM_NAME = egg64
 
-LIBDRAGON = /opt/libdragon
+LIBDRAGON ?= /opt/libdragon
 
 CC = mips64-elf-gcc
 CFLAGS = -I$(LIBDRAGON)/mips64-elf/include -Iinclude -std=gnu99 -O2

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Nintendo 64 homebrew project about an egg.
 ## Building
 
 1. Clone this repository.
-2. Ensure the `LIBDRAGON` path in the `Makefile` points to your libdragon installation.
+2. Ensure the `LIBDRAGON` path in the `Makefile` points to your libdragon installation. Alternatively, run `make LIBDRAGON=/path/to/libdragon` to override the default.
 3. Run `make`. The default target builds `egg64.z64`.
 4. Use `make clean` to remove build artifacts.
 


### PR DESCRIPTION
## Summary
- make LIBDRAGON path overrideable with `?=`
- document overriding via `make LIBDRAGON=/path/to/libdragon`

## Testing
- `make` *(fails: mips64-elf-gcc missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840c2ddf5948328a44c6a63aade9386