### PR TITLE
Update CFLAGS for warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ROM_NAME = egg64
 LIBDRAGON = /opt/libdragon
 
 CC = mips64-elf-gcc
-CFLAGS = -I$(LIBDRAGON)/mips64-elf/include -Iinclude -std=gnu99 -O2
+CFLAGS = -I$(LIBDRAGON)/mips64-elf/include -Iinclude -std=gnu99 -O2 -Wall -Wextra
 
 LD = mips64-elf-ld
 LDFLAGS = -L$(LIBDRAGON)/mips64-elf/lib -ldragon -ldragonsys -lc -lm -lgcc -lnosys


### PR DESCRIPTION
## Summary
- enable compile-time warnings by adding `-Wall -Wextra` to `CFLAGS`

## Testing
- `apt-get install -y gcc-mips64-linux-gnuabi64 binutils-mips64-linux-gnuabi64`
- `make` *(fails: mips64-elf-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c2dd24408328909af518729e25ac