### PR TITLE
Use display size in draw_model

### DIFF
--- a/src/model_loader.c
+++ b/src/model_loader.c
@@ -76,6 +76,9 @@ static void rotate_y(float x, float z, float angle, float *out_x,
 void draw_model(model_t *model, surface_t *disp, float angle) {
   rdpq_attach(disp, NULL);
 
+  float half_w = disp->width / 2.0f;
+  float half_h = disp->height / 2.0f;
+
   color_t gold = RGBA32(255, 215, 0, 255);
   rdpq_set_mode_fill(gold);
 
@@ -105,8 +108,8 @@ void draw_model(model_t *model, surface_t *disp, float angle) {
         goto skip_triangle;
 
       float scale = 200.0f / (rz + 3.0f);
-      int sx = (int)(160 + rx * scale);
-      int sy = (int)(120 - y * scale);
+      int sx = (int)(half_w + rx * scale);
+      int sy = (int)(half_h - y * scale);
 
       screen_coords[j][0] = sx;
       screen_coords[j][1] = sy;


### PR DESCRIPTION
## Summary
- use disp->width and disp->height in `draw_model`
- center model based on the display dimensions

## Testing
- `make` *(fails: `mips64-elf-gcc: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6840c2dc90f4832887c73b4ac5503090