### PR TITLE
Add model load check

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ A Nintendo 64 homebrew project about an egg.
 2. Ensure the `LIBDRAGON` path in the `Makefile` points to your libdragon installation.
 3. Run `make`. The default target builds `egg64.z64`.
 4. Use `make clean` to remove build artifacts.
+5. When the ROM starts, it verifies that `egg.obj` loaded correctly. If the
+   model fails to load, an error is printed and the program exits.
 
 `egg64.z64` can be loaded in an emulator or on hardware.
 

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,7 @@
 // src/main.c
 
 #include "model_loader.h"
+#include <stdio.h>
 
 int main(void) {
   display_init(RESOLUTION_320x240, DEPTH_16_BPP, 2, GAMMA_NONE,
@@ -12,6 +13,14 @@ int main(void) {
   rspq_init();
 
   model_t egg_model = load_obj_model("rom:/egg.obj");
+  if (egg_model.vertex_count == 0 || egg_model.vertices == NULL) {
+    printf("Failed to load egg model\n");
+    free_model(&egg_model);
+    rdpq_close();
+    rspq_close();
+    display_close();
+    return 1;
+  }
   float angle = 0.0f;
 
   while (1) {


### PR DESCRIPTION
## Summary
- exit gracefully if the OBJ model doesn't load
- document model loading check

## Testing
- `make` *(fails: mips64-elf-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c2db32308328b601101cb49b847b