### PR TITLE
CI: install libdragon toolchain package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,11 @@ jobs:
 
       - name: Install libdragon toolchain
         run: |
-          git clone --depth 1 https://github.com/DragonMinded/libdragon.git /tmp/libdragon
-          sudo make -C /tmp/libdragon/tools install
+          TOOLCHAIN_URL="https://github.com/DragonMinded/libdragon/releases/download/toolchain-continuous-prerelease/gcc-toolchain-mips64-x86_64.deb"
+          wget --quiet "$TOOLCHAIN_URL" -O /tmp/libdragon-toolchain.deb
+          sudo apt-get install -y /tmp/libdragon-toolchain.deb
           echo "/opt/libdragon/bin" >> "$GITHUB_PATH"
+          echo "N64_INST=/opt/libdragon" >> "$GITHUB_ENV"
 
       - name: Build ROM
         run: make


### PR DESCRIPTION
## Summary
- install Libdragon's prebuilt MIPS64 toolchain package during CI
- expose the toolchain binaries and N64_INST to subsequent steps

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68f7dc5f151c8328ace641e22621cf85