### PR TITLE
Fix libdragon toolchain defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,17 @@
 ROM_NAME = egg64
 
 LIBDRAGON ?= /opt/libdragon
+TOOLCHAIN ?= $(LIBDRAGON)/mips64-elf/bin
+MIPS_PREFIX ?= $(TOOLCHAIN)/mips64-elf-
 
-CC = mips64-elf-gcc
+CC = $(MIPS_PREFIX)gcc
 CFLAGS = -I$(LIBDRAGON)/mips64-elf/include -Iinclude -std=gnu99 -O2 -Wall -Wextra
 
-LD = mips64-elf-ld
+LD = $(MIPS_PREFIX)ld
 LDFLAGS = -L$(LIBDRAGON)/mips64-elf/lib -ldragon -ldragonsys -lc -lm -lgcc -lnosys
 
-OBJCOPY = mips64-elf-objcopy
-N64TOOL = n64tool
+OBJCOPY = $(MIPS_PREFIX)objcopy
+N64TOOL ?= $(LIBDRAGON)/bin/n64tool
 
 OBJS = build/main.o build/model_loader.o
 


### PR DESCRIPTION
## Summary
- default to using the libdragon toolchain binaries from the configured installation path
- add a configurable prefix for the MIPS toolchain binaries
- default `n64tool` to the libdragon-provided executable when available

## Testing
- not run (MIPS64 toolchain not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68f7deb4d7848328bcfed5b992bde20a