### PR TITLE
Fix default libdragon toolchain path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,11 @@
 ROM_NAME = egg64
 
 LIBDRAGON ?= /opt/libdragon
-TOOLCHAIN ?= $(LIBDRAGON)/mips64-elf/bin
+# The libdragon toolchain installs the cross-compilers in the top-level
+# "bin" directory rather than under mips64-elf/.  Point the toolchain
+# directory there so CC resolves to /opt/libdragon/bin/mips64-elf-gcc by
+# default.
+TOOLCHAIN ?= $(LIBDRAGON)/bin
 MIPS_PREFIX ?= $(TOOLCHAIN)/mips64-elf-
 
 CC = $(MIPS_PREFIX)gcc


### PR DESCRIPTION
## Summary
- point the default toolchain directory to the libdragon bin folder so mips64-elf-gcc can be found
- document the reasoning inline in the Makefile for future maintainers

## Testing
- make *(fails: libdragon toolchain is not installed in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f7e051affc83289c510edeeb706c7f