### PR TITLE
Make free_model idempotent and null-safe

### DIFF
--- a/include/model_loader.h
+++ b/include/model_loader.h
@@ -14,4 +14,6 @@ typedef struct {
 // fails.
 model_t load_obj_model(const char *path);
 void draw_model(model_t *model, surface_t *disp, float angle);
+// Free model allocations and reset all fields.
+// Safe to call multiple times on the same model instance.
 void free_model(model_t *model);

--- a/src/model_loader.c
+++ b/src/model_loader.c
@@ -210,8 +210,16 @@ void draw_model(model_t *model, surface_t *disp, float angle) {
 }
 
 void free_model(model_t *model) {
+  if (!model)
+    return;
+
   if (model->vertices)
     free(model->vertices);
   if (model->indices)
     free(model->indices);
+
+  model->vertices = NULL;
+  model->indices = NULL;
+  model->vertex_count = 0;
+  model->index_count = 0;
 }


### PR DESCRIPTION
### Motivation
- Prevent invalid dereference and make cleanup safe when callers pass a null pointer to the free routine.
- Ensure model instances are in a well-defined, inspectable state after cleanup so callers can reuse or re-free them safely.

### Description
- Add a null-pointer guard to `free_model` so it returns immediately if `model` is `NULL`.
- Free `model->vertices` and `model->indices` only if non-NULL and then set those pointers to `NULL` in `src/model_loader.c`.
- Reset `model->vertex_count` and `model->index_count` to `0` after freeing in `src/model_loader.c`.
- Update `include/model_loader.h` header comments to state that `free_model` is safe to call multiple times.

### Testing
- Verified the source diff with `git diff -- src/model_loader.c include/model_loader.h` and the changes show the intended edits.
- Printed and inspected the updated regions with `nl -ba src/model_loader.c | sed -n '206,236p'` and `nl -ba include/model_loader.h | sed -n '1,40p'`, which matched the expected modifications.
- The patch application checks completed successfully during the update process.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c808c9e33c832880cc09de7b8d3b8c)