### PR TITLE
Harden OBJ model loading validation and safe abort paths

### DIFF
--- a/src/model_loader.c
+++ b/src/model_loader.c
@@ -29,16 +29,13 @@ model_t load_obj_model(const char *path) {
   model.vertices = malloc(sizeof(float) * 3 * v_count);
   if (!model.vertices) {
     printf("Could not allocate vertices\n");
-    fclose(f);
-    return (model_t){0};
+    goto fail;
   }
 
   model.indices = malloc(sizeof(int) * 3 * f_count);
   if (!model.indices) {
     printf("Could not allocate indices\n");
-    free(model.vertices);
-    fclose(f);
-    return (model_t){0};
+    goto fail;
   }
 
   model.vertex_count = v_count;
@@ -47,24 +44,56 @@ model_t load_obj_model(const char *path) {
   rewind(f);
 
   int vi = 0, ii = 0;
+  int line_no = 0;
   while (fgets(line, sizeof(line), f)) {
+    line_no++;
+
     if (strncmp(line, "v ", 2) == 0) {
       float x, y, z;
-      sscanf(line, "v %f %f %f", &x, &y, &z);
+      int parsed = sscanf(line, "v %f %f %f", &x, &y, &z);
+      if (parsed != 3) {
+        printf("OBJ parse error at line %d (vertex): %s", line_no, line);
+        goto fail;
+      }
+
       model.vertices[vi++] = x;
       model.vertices[vi++] = y;
       model.vertices[vi++] = z;
     } else if (strncmp(line, "f ", 2) == 0) {
       int a, b, c;
-      sscanf(line, "f %d %d %d", &a, &b, &c);
-      model.indices[ii++] = a - 1;
-      model.indices[ii++] = b - 1;
-      model.indices[ii++] = c - 1;
+      int parsed = sscanf(line, "f %d %d %d", &a, &b, &c);
+      if (parsed != 3) {
+        printf("OBJ parse error at line %d (face): %s", line_no, line);
+        goto fail;
+      }
+
+      int face_indices[3] = {a - 1, b - 1, c - 1};
+      for (int j = 0; j < 3; j++) {
+        if (face_indices[j] < 0 || face_indices[j] >= model.vertex_count) {
+          printf("OBJ invalid vertex index at line %d: %s", line_no, line);
+          goto fail;
+        }
+        model.indices[ii++] = face_indices[j];
+      }
     }
+  }
+
+  if (vi != model.vertex_count * 3 || ii != model.index_count) {
+    printf("OBJ integrity check failed: vi=%d expected=%d, ii=%d expected=%d\n",
+           vi, model.vertex_count * 3, ii, model.index_count);
+    goto fail;
   }
 
   fclose(f);
   return model;
+
+fail:
+  if (model.vertices)
+    free(model.vertices);
+  if (model.indices)
+    free(model.indices);
+  fclose(f);
+  return (model_t){0};
 }
 
 static void rotate_y(float x, float z, float angle, float *out_x,


### PR DESCRIPTION
### Motivation
- Prevent crashes and silently malformed models by tightening OBJ parsing and index validation in the loader. 
- Ensure that partially-allocated resources are freed and files are closed on any parse/allocation error to avoid leaks.

### Description
- Add `sscanf` return-count checks for `v` and `f` lines and print descriptive error messages including the source line number and raw line content when parsing fails.
- Track input line numbers and validate each parsed face index against `vertex_count` before writing into the indices array, printing an error and aborting on invalid indices.
- Introduce a single `fail:` cleanup path that frees `model.vertices` and `model.indices`, closes the file, and returns an empty `model_t` on any failure.
- Add a final integrity check that verifies `vi == model.vertex_count * 3` and `ii == model.index_count` before returning the populated model.

### Testing
- Ran `make` in the environment which failed because the cross-compiler `/mips64-elf-gcc` is not available, so the code could not be built here (no additional automated tests were run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c808b4d8d48328819b3e40b426d389)