### PR TITLE
Add CI workflow with strict warning checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,54 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      LIBDRAGON: /opt/libdragon
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build ROM
+        run: make
+
+      - name: Strict warning compile (non-blocking)
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          make clean
+          make EXTRA_WARNINGS="-Wshadow -Wconversion" 2>&1 | tee strict-warnings.log
+
+      - name: Fail on project warnings from strict compile
+        if: always()
+        run: |
+          python3 - <<'PY'
+          import re
+          from pathlib import Path
+
+          log_path = Path('strict-warnings.log')
+          if not log_path.exists():
+              print('strict-warnings.log was not produced; strict compile likely failed before logging warnings.')
+              raise SystemExit(0)
+
+          warning_re = re.compile(r'^(src|include)/[^:\n]+:\d+:\d+: warning:')
+          warnings = []
+
+          for line in log_path.read_text(encoding='utf-8', errors='replace').splitlines():
+              if warning_re.search(line):
+                  warnings.append(line)
+
+          if warnings:
+              print('Project warnings detected during strict compile:')
+              for warning in warnings:
+                  print(warning)
+              raise SystemExit(1)
+
+          print('No project warnings detected during strict compile.')
+          PY

--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,21 @@ MIPS_PREFIX ?= $(TOOLCHAIN)/mips64-elf-
 CC  = $(MIPS_PREFIX)gcc
 LD  = $(MIPS_PREFIX)gcc
 
-# Use the top-level include directory with modern libdragon.  The cross
-# compiler already knows how to search $(MIPS_PREFIX)include, so there is
-# no need to explicitly include it.  Suppress deprecation warnings as
-# errors because libdragon deprecated some APIs (like controller_scan) but
-# still provides them.  Failing compilation on deprecation warnings would
-# break the build.
-CFLAGS = -I$(LIBDRAGON)/include -Iinclude -std=gnu99 -O2 -Wall -Wextra \
-    -Wno-error=deprecated-declarations
+# Use the top-level include directory with modern libdragon.
+#
+# We include libdragon through -isystem so warnings coming from SDK headers do
+# not drown out warnings from project code when running stricter CI checks.
+#
+# Deliberate suppression: keep deprecated libdragon APIs as non-fatal because
+# some currently-used APIs (for example controller_scan) are intentionally
+# deprecated but still required for compatibility.
+BASE_CFLAGS = -isystem $(LIBDRAGON)/include -Iinclude -std=gnu99 -O2 -Wall \
+    -Wextra -Wno-error=deprecated-declarations
+
+# Optional warning flags used by stricter local/CI checks.
+EXTRA_WARNINGS ?=
+
+CFLAGS = $(BASE_CFLAGS) $(EXTRA_WARNINGS)
 
 # Link against libdragon.  The modern layout installs libraries under
 # $(LIBDRAGON)/lib; the linker will search the appropriate libgcc/nostd

--- a/README.md
+++ b/README.md
@@ -20,6 +20,23 @@ A Nintendo 64 homebrew project about an egg.
 
 `egg64.z64` can be loaded in an emulator or on hardware.
 
+## Development checks
+
+Run these before opening a PR:
+
+1. Standard build check:
+   - `make clean && make`
+2. Stricter warning check:
+   - `make clean && make EXTRA_WARNINGS="-Wshadow -Wconversion"`
+
+Notes about warnings/suppressions:
+
+- The build deliberately uses `-Wno-error=deprecated-declarations` because
+  some libdragon APIs currently used by this project are deprecated but still
+  required for compatibility.
+- libdragon headers are added with `-isystem` so strict warning checks focus on
+  project code (`src/` and `include/`) instead of third-party SDK noise.
+
 ## License
 
 This project is licensed under the terms of the [MIT License](LICENSE).


### PR DESCRIPTION
### Motivation

- Prevent regressions in compilation and parser-related safety by running builds and stricter warning checks automatically on push and PRs.
- Make strict warning checks focus on project code while avoiding noise from the libdragon SDK.
- Provide a documented local validation flow so contributors can reproduce CI checks before opening PRs.

### Description

- Add a GitHub Actions workflow at `.github/workflows/build.yml` that runs `make` on `push` to `main` and on `pull_request`, and performs a non-blocking strict-compile step using `EXTRA_WARNINGS="-Wshadow -Wconversion"` with output captured to `strict-warnings.log`.
- Add a follow-up workflow step that parses `strict-warnings.log` and fails the job only if warnings originate from project paths (`src/` or `include/`).
- Refactor `Makefile` to introduce `BASE_CFLAGS` and `EXTRA_WARNINGS`, switch libdragon includes to use `-isystem` to suppress third-party warnings, and keep `-Wno-error=deprecated-declarations` to avoid failing on intentionally deprecated libdragon APIs.
- Document local validation steps and the rationale for suppressions in `README.md` under a new “Development checks” section.

### Testing

- Ran `make clean && make` in the verification environment, which failed because the cross-compiler `mips64-elf-gcc` was not available (expected in the normal build environment); no project compile-time warnings were produced in this run due to the failure.
- Ran `make clean && make EXTRA_WARNINGS="-Wshadow -Wconversion"` which also failed for the same missing cross-compiler; `strict-warnings.log` could not be generated locally for the same reason.
- The workflow includes an automated parser step that will run on GitHub and fail CI if project warnings are found during the strict compile.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c808d070f88328a08685058a75430a)